### PR TITLE
Avoid Instant and LocalDate GSON serialization errors (Java 17+)

### DIFF
--- a/src/main/java/com/mailersend/sdk/emails/Email.java
+++ b/src/main/java/com/mailersend/sdk/emails/Email.java
@@ -9,6 +9,7 @@ package com.mailersend.sdk.emails;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -446,6 +447,7 @@ public class Email {
                 .addSerializationExclusionStrategy(new JsonSerializationDeserializationStrategy(false))
                 .addDeserializationExclusionStrategy(new JsonSerializationDeserializationStrategy(true))
                 .registerTypeAdapter(LocalDate.class, new LocalDateTypeAdapter().nullSafe())
+                .registerTypeAdapter(Instant.class, new InstantTypeAdapter().nullSafe())
                 .create();
         
         String json = gson.toJson(this);
@@ -469,6 +471,25 @@ public class Email {
         @Override
         public LocalDate read(JsonReader in) throws IOException {
           return LocalDate.parse(in.nextString());
+        }
+    }
+
+    /**
+    * Simple adapter for {@link Instant} type in Gson serialization.
+    *
+    * To use this {@link Instant}, register it into a {@link Gson} serializer using a
+    * {@link GsonBuilder}.
+    */
+    class InstantTypeAdapter extends TypeAdapter<Instant> {
+
+        @Override
+        public void write(JsonWriter out, Instant value) throws IOException {
+          out.value(value.toString());
+        }
+
+        @Override
+        public Instant read(JsonReader in) throws IOException {
+          return Instant.parse(in.nextString());
         }
     }
 }

--- a/src/main/java/com/mailersend/sdk/emails/Email.java
+++ b/src/main/java/com/mailersend/sdk/emails/Email.java
@@ -9,6 +9,7 @@ package com.mailersend.sdk.emails;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -16,7 +17,10 @@ import java.util.HashMap;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 import com.mailersend.sdk.Recipient;
 import com.mailersend.sdk.util.JsonSerializationDeserializationStrategy;
 
@@ -441,10 +445,30 @@ public class Email {
         Gson gson = new GsonBuilder()
                 .addSerializationExclusionStrategy(new JsonSerializationDeserializationStrategy(false))
                 .addDeserializationExclusionStrategy(new JsonSerializationDeserializationStrategy(true))
+                .registerTypeAdapter(LocalDate.class, new LocalDateTypeAdapter().nullSafe())
                 .create();
         
         String json = gson.toJson(this);
 
         return json;
+    }
+
+    /**
+    * Simple adapter for {@link LocalDate} type in Gson serialization.
+    *
+    * To use this {@link TypeAdapter}, register it into a {@link Gson} serializer using a
+    * {@link GsonBuilder}.
+    */
+    class LocalDateTypeAdapter extends TypeAdapter<LocalDate> {
+
+        @Override
+        public void write(JsonWriter out, LocalDate value) throws IOException {
+          out.value(value.toString());
+        }
+
+        @Override
+        public LocalDate read(JsonReader in) throws IOException {
+          return LocalDate.parse(in.nextString());
+        }
     }
 }


### PR DESCRIPTION
Mailersend uses the default GSON serializer for serializing some classes when using then `com.mailersend.sdk.emails.Email.serializeForSending` method. The default GSON serializer uses reflection to serialize such classes; this is not compatible with a change made in the JDK for Java 17 (see JEP 403 or https://github.com/google/gson/blob/main/Troubleshooting.md#-inaccessibleobjectexception-module--does-not-opens--to-unnamed-module) regarding reflection, causing a `com.google.gson.JsonIOException` to be thrown when calling the `com.mailersend.sdk.emails.Email.serializeForSending` method.

For the Mailersend client, this problem usually happens when you pass an Object that contains fields of type `java.time.LocalDate` or `java.time.Instant` to the `com.mailersend.sdk.emails.Email.addPersonalization` method and then send the email using the `com.mailersend.sdk.emails.Emails.send` method.

GSON's suggested solution says:

> Write custom Gson [TypeAdapter](https://www.javadoc.io/doc/com.google.code.gson/gson/latest/com.google.gson/com/google/gson/TypeAdapter.html) implementations for the affected classes or change the type of your data. If this occurs for a field in one of your classes which you did not actually want to serialize or deserialize in the first place, you can exclude that field, see the [user guide](https://github.com/google/gson/blob/main/UserGuide.md#excluding-fields-from-serialization-and-deserialization).

As the second option would imply changing the `com.mailersend.sdk.emails.Email.addPersonalization` method or restricting the classes that can be serialized, I have implemented the first solution by adding TypeAdapters for the `java.time.LocalDate` and `java.time.Instant` classes.