### PR TITLE
fixes ScheduleEmailTest, adds and improves assertions

### DIFF
--- a/src/test/resources/fixtures/EmailSendTest_ScheduleEmailTest().json
+++ b/src/test/resources/fixtures/EmailSendTest_ScheduleEmailTest().json
@@ -1,1 +1,122 @@
-{"d7f242eada3144a0e09e58a50e39db613b826590":{"body":"","headers":{":status":["202"],"cache-control":["no-cache, private"],"cf-cache-status":["DYNAMIC"],"cf-ray":["8ac5d0d95b7f7176-ATH"],"content-type":["text/html; charset\u003dUTF-8"],"date":["Thu, 01 Aug 2024 12:26:18 GMT"],"server":["cloudflare"],"strict-transport-security":["max-age\u003d31536000; includeSubDomains"],"x-apiquota-remaining":["-1"],"x-apiquota-reset":["2024-08-02T00:00:00Z"],"x-message-id":["66ab7eea1101995a278ad874"]},"statusCode":202},"6b15cf69672ee532a9f601876778851cc4ca3135":{"body":"","headers":{":status":["202"],"cache-control":["no-cache, private"],"cf-cache-status":["DYNAMIC"],"cf-ray":["755442149ddbeea0-ATH"],"content-type":["text/html; charset\u003dUTF-8"],"date":["Wed, 05 Oct 2022 06:56:34 GMT"],"server":["cloudflare"],"strict-transport-security":["max-age\u003d15724800; includeSubDomains"],"x-apiquota-remaining":["-1"],"x-apiquota-reset":["2022-10-06T00:00:00Z"],"x-message-id":["633d2aa226762ac1d30457e0"],"x-ratelimit-limit":["120"],"x-ratelimit-remaining":["118"]},"statusCode":202},"e4a0bcf8b4e53b4dcfb4d96b2db3d8a0054a92f2":{"body":"{\"message\":\"The send_at must be a date before or equal to 2024-08-04 12:24:25.\",\"errors\":{\"send_at\":[\"The send_at must be a date before or equal to 2024-08-04 12:24:25.\"]}}","headers":{":status":["422"],"cache-control":["no-cache, private"],"cf-cache-status":["DYNAMIC"],"cf-ray":["8ac5ce134f316f56-ATH"],"content-type":["application/json"],"date":["Thu, 01 Aug 2024 12:24:25 GMT"],"server":["cloudflare"],"strict-transport-security":["max-age\u003d31536000; includeSubDomains"],"x-apiquota-remaining":["-1"],"x-apiquota-reset":["2024-08-02T00:00:00Z"]},"statusCode":422}}
+{
+  "4f6a751939688d9c22a55807b9b1717ea74552f7": {
+    "body": "",
+    "headers": {
+      ":status": [
+        "202"
+      ],
+      "cache-control": [
+        "no-cache, private"
+      ],
+      "cf-cache-status": [
+        "DYNAMIC"
+      ],
+      "cf-ray": [
+        "8ac5d0d95b7f7176-ATH"
+      ],
+      "content-type": [
+        "text/html; charset\u003dUTF-8"
+      ],
+      "date": [
+        "Thu, 01 Aug 2024 12:26:18 GMT"
+      ],
+      "server": [
+        "cloudflare"
+      ],
+      "strict-transport-security": [
+        "max-age\u003d31536000; includeSubDomains"
+      ],
+      "x-apiquota-remaining": [
+        "-1"
+      ],
+      "x-apiquota-reset": [
+        "2024-08-02T00:00:00Z"
+      ],
+      "x-message-id": [
+        "66ab7eea1101995a278ad874"
+      ]
+    },
+    "statusCode": 202
+  },
+  "6b15cf69672ee532a9f601876778851cc4ca3135": {
+    "body": "",
+    "headers": {
+      ":status": [
+        "202"
+      ],
+      "cache-control": [
+        "no-cache, private"
+      ],
+      "cf-cache-status": [
+        "DYNAMIC"
+      ],
+      "cf-ray": [
+        "755442149ddbeea0-ATH"
+      ],
+      "content-type": [
+        "text/html; charset\u003dUTF-8"
+      ],
+      "date": [
+        "Wed, 05 Oct 2022 06:56:34 GMT"
+      ],
+      "server": [
+        "cloudflare"
+      ],
+      "strict-transport-security": [
+        "max-age\u003d15724800; includeSubDomains"
+      ],
+      "x-apiquota-remaining": [
+        "-1"
+      ],
+      "x-apiquota-reset": [
+        "2022-10-06T00:00:00Z"
+      ],
+      "x-message-id": [
+        "633d2aa226762ac1d30457e0"
+      ],
+      "x-ratelimit-limit": [
+        "120"
+      ],
+      "x-ratelimit-remaining": [
+        "118"
+      ]
+    },
+    "statusCode": 202
+  },
+  "e4a0bcf8b4e53b4dcfb4d96b2db3d8a0054a92f2": {
+    "body": "{\"message\":\"The send_at must be a date before or equal to 2024-08-04 12:24:25.\",\"errors\":{\"send_at\":[\"The send_at must be a date before or equal to 2024-08-04 12:24:25.\"]}}",
+    "headers": {
+      ":status": [
+        "422"
+      ],
+      "cache-control": [
+        "no-cache, private"
+      ],
+      "cf-cache-status": [
+        "DYNAMIC"
+      ],
+      "cf-ray": [
+        "8ac5ce134f316f56-ATH"
+      ],
+      "content-type": [
+        "application/json"
+      ],
+      "date": [
+        "Thu, 01 Aug 2024 12:24:25 GMT"
+      ],
+      "server": [
+        "cloudflare"
+      ],
+      "strict-transport-security": [
+        "max-age\u003d31536000; includeSubDomains"
+      ],
+      "x-apiquota-remaining": [
+        "-1"
+      ],
+      "x-apiquota-reset": [
+        "2024-08-02T00:00:00Z"
+      ]
+    },
+    "statusCode": 422
+  }
+}


### PR DESCRIPTION
The test `ScheduleEmailTest` is failing when I run `mvn clean test`. I've updated a hash in tapes.

While at that I took a liberty to also:

1. remove unused imports
2. remove try-catch blocks
3. add asserts to tests where missing
4. fix wrong order in asserts
<img width="507" alt="image" src="https://github.com/user-attachments/assets/554cb4dd-399e-403f-96a9-97175e9bcc45" />

