### PR TITLE
Wrong import statement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Through the `MailerSendResponse` object you can get the ID of the sent message, 
 ### Send an email
 
 ```java
-import com.mailersend.sdk.Email;
+import com.mailersend.sdk.emails.Email;
 import com.mailersend.sdk.MailerSend;
 import com.mailersend.sdk.MailerSendResponse;
 import com.mailersend.sdk.exceptions.MailerSendException;


### PR DESCRIPTION
Wrong import in "Send Email" description.

The import in line 141  was com.mailersend.sdk.Email; but it is described in all other examples as import com.mailersend.sdk.emails.Email; - this import works, but the other one cannot be resolved by the IDE