### PR TITLE
Add optional language field to email send

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ MailerSend Java SDK
         - [Send an email](#send-an-email)
         - [Add CC, BCC recipients](#add-cc-bcc-recipients)
         - [Send a template-based email](#send-a-template-based-email)
+        - [Send a template-based email in a specific language](#send-a-template-based-email-in-a-specific-language)
         - [Personalization](#personalization)
         - [Send email with attachment](#send-email-with-attachment)
         - [Send email with inline attachment](#send-email-with-inline-attachment)
@@ -297,6 +298,45 @@ public void sendEmail() {
 
     try {
     
+        MailerSendResponse response = ms.emails().send(email);
+        System.out.println(response.messageId);
+    } catch (MailerSendException e) {
+
+        e.printStackTrace();
+    }
+}
+```
+
+### Send a template-based email in a specific language
+
+The optional `language` field is a language code that selects a template translation. It is only meaningful when a template id is set and is ignored
+for raw HTML/text sends. Supported values: `de`, `en`, `es`, `fr`, `it`, `lt`, `nl`, `pl`, `pt-BR`.
+
+```java
+import com.mailersend.sdk.emails.Email;
+import com.mailersend.sdk.MailerSend;
+import com.mailersend.sdk.MailerSendResponse;
+import com.mailersend.sdk.exceptions.MailerSendException;
+
+public void sendEmail() {
+
+    Email email = new Email();
+
+    email.setFrom("name", "your email");
+
+    Recipient recipient = new Recipient("name", "your@recipient.com");
+
+    email.addRecipient(recipient);
+
+    email.setTemplateId("Your MailerSend template ID");
+    email.setLanguage("pt-BR");
+
+    MailerSend ms = new MailerSend();
+
+    ms.setToken("Your API token");
+
+    try {
+
         MailerSendResponse response = ms.emails().send(email);
         System.out.println(response.messageId);
     } catch (MailerSendException e) {

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ Using Maven:
     <dependency>
       <groupId>com.mailersend</groupId>
       <artifactId>java-sdk</artifactId>
-      <version>1.5.0</version>
+      <version>2.1.0</version>
     </dependency>
 
 Using Gradle:
 
-    implementation 'com.mailersend:java-sdk:1.5.0'
+    implementation 'com.mailersend:java-sdk:2.1.0'
     
 # Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mailersend</groupId>
 	<artifactId>java-sdk</artifactId>
-	<version>2.0.0</version>
+	<version>2.1.0</version>
 	<name>MailerSend Java SDK</name>
 	<description>An SDK for MailerSend API</description>
 	<url>https://github.com/mailersend/mailersend-java</url>

--- a/src/main/java/com/mailersend/sdk/emails/Email.java
+++ b/src/main/java/com/mailersend/sdk/emails/Email.java
@@ -64,6 +64,9 @@ public class Email {
     @SerializedName("template_id")
     public String templateId;
 
+    @SerializedName("language")
+    public String language;
+
     @SerializedName("tags")
     public ArrayList<String> tags = new ArrayList<String>();
     
@@ -384,10 +387,23 @@ public class Email {
      * @param templateId a {@link java.lang.String} object.
      */
     public void setTemplateId(String templateId) {
-        
+
         this.templateId = templateId;
     }
-    
+
+
+    /**
+     * Sets the email's template translation language as a language code
+     * (e.g. "de", "fr", "pt-BR"). Only meaningful when a template id is set;
+     * ignored for raw html/text sends.
+     *
+     * @param language a {@link java.lang.String} object.
+     */
+    public void setLanguage(String language) {
+
+        this.language = language;
+    }
+
     
     /**
      * Adds a personalization for the given recipient

--- a/src/test/java/com/mailersend/sdk/tests/EmailConfigurationTest.java
+++ b/src/test/java/com/mailersend/sdk/tests/EmailConfigurationTest.java
@@ -357,4 +357,38 @@ public class EmailConfigurationTest {
         assertEquals("reply name 2", email.replyTo.name);
         assertEquals("reply2@test.com", email.replyTo.email);
     }
+
+
+    /**
+     * Tests that setLanguage stores the language and it serializes as "language" in JSON
+     */
+    @Test
+    public void testLanguageSerialization() {
+
+        Email email = TestHelper.createBasicEmail(true);
+
+        email.setTemplateId("neqvygm021wl0p7w");
+        email.setLanguage("pt-BR");
+
+        assertEquals("pt-BR", email.language);
+
+        String json = email.serializeForSending();
+
+        assertTrue(json.contains("\"language\""));
+        assertTrue(json.contains("pt-BR"));
+    }
+
+
+    /**
+     * Tests that the language field is omitted from the JSON when not set
+     */
+    @Test
+    public void testLanguageOmittedWhenNotSet() {
+
+        Email email = TestHelper.createBasicEmail(true);
+
+        String json = email.serializeForSending();
+
+        assertTrue(!json.contains("\"language\""));
+    }
 }


### PR DESCRIPTION
resolves [MSD-14489](https://linear.app/mailerlite/issue/MSD-14489/document-language-field-on-email-send-api-and-sdks)

Surfaces the new optional `language` field from the API's template-translations feature (MSD-14341) in the SDK.

### Changelist
- Add an optional `language` parameter to the email-send builder/params (e.g. `setLanguage("de")` / `.language("de")`), mirroring how `template_id` is handled.
- Include `language` in the request payload only when set; both single and bulk sends covered.
- README: add a short template + language example.
